### PR TITLE
REWORK CHAT SERVICE:

### DIFF
--- a/back/src/chat/channel/channel.service.ts
+++ b/back/src/chat/channel/channel.service.ts
@@ -315,7 +315,7 @@ export class ChannelService {
 				where: { connectionId: { userId: targetId, channelId: targetChannelId } },
 				data: { role: ChannelRole.INVITED }
 			});
-			this.chatService.emitToUser(targetId, 'chat:invite', invite);
+			this.chatService.emitToUser('chat:invite', invite, targetId);
 			return invite;
 		}
 		const invite = await this.prisma.channelConnection
@@ -331,7 +331,7 @@ export class ChannelService {
 					description: 'user does not exist'
 				});
 			});
-		this.chatService.emitToUser(targetId, 'chat:invite', invite);
+		this.chatService.emitToUser('chat:invite', invite, targetId);
 		return invite;
 	}
 
@@ -364,7 +364,7 @@ export class ChannelService {
 					description: 'user does not exist'
 				});
 			});
-		this.chatService.emitToUser(targetId, 'chat:kick', channel);
+		this.chatService.emitToUser('chat:kick', channel, targetId);
 		return null;
 	}
 
@@ -403,7 +403,7 @@ export class ChannelService {
 					description: 'user does not exist'
 				});
 			});
-		this.chatService.emitToUser(targetId, 'chat:ban', banned);
+		this.chatService.emitToUser('chat:ban', banned, targetId);
 		return banned;
 	}
 

--- a/back/src/chat/chat.gateway.ts
+++ b/back/src/chat/chat.gateway.ts
@@ -1,15 +1,9 @@
-import {
-	OnGatewayConnection,
-	OnGatewayDisconnect,
-	OnGatewayInit,
-	WebSocketGateway,
-	WebSocketServer
-} from '@nestjs/websockets';
-import { Server } from 'socket.io';
+import { OnGatewayConnection, OnGatewayInit, WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
 import { AuthService } from '@auth/auth.service';
 import { ChatService } from './chat.service';
 import authConfig from '@config/auth.config';
 import Socket from '@type/socket';
+import type { Server } from '@type/server';
 
 @WebSocketGateway({
 	namespace: 'chat',
@@ -18,7 +12,7 @@ import Socket from '@type/socket';
 		credentials: true
 	}
 })
-export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
+export class ChatGateway implements OnGatewayInit, OnGatewayConnection {
 	@WebSocketServer() server: Server;
 
 	constructor(
@@ -33,10 +27,6 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
 	async handleConnection(socket: Socket): Promise<void> {
 		const user = await this.authService.getWsUser(socket);
 		if (!user) socket.disconnect(true);
-		else this.chatService.onConnection(socket);
-	}
-
-	async handleDisconnect(socket: Socket): Promise<void> {
-		if (socket.user) this.chatService.onDisconnection(socket);
+		else await this.chatService.onConnection(socket);
 	}
 }

--- a/back/src/chat/chat.service.ts
+++ b/back/src/chat/chat.service.ts
@@ -6,6 +6,8 @@ import type { Server } from '@type/server';
 export class ChatService {
 	server: Server;
 
+	// Get all sockets for a given userId, return an object with a list of sockets and a list of socket ids
+	// Example: { sockets: [socket1, socket2], socketIds: [socket1.id, socket2.id] }
 	async fetchSockets(userId: number) {
 		const sockets = await this.server.in(`user:${userId}`).fetchSockets();
 		return { sockets, socketIds: sockets.map((socket) => socket.id) };
@@ -13,6 +15,9 @@ export class ChatService {
 
 	async onConnection(socket: Socket) {
 		socket.join(`user:${socket.user.id}`);
+
+		// Simply log the socket ids of the user
+		// here we fetch the sockets of the user and store them in the socketIds variable. Then we log them.
 		const { socketIds } = await this.fetchSockets(socket.user.id);
 		console.log(`${socket.user.username} (onConnection): `, socketIds);
 	}
@@ -22,7 +27,7 @@ export class ChatService {
 		else this.server.emit(event, data);
 	}
 
-	emitToUser(userId: number, event: string, data: any): void {
+	emitToUser(event: string, data: any, userId: number): void {
 		this.emit(event, data, `user:${userId}`);
 	}
 

--- a/back/src/chat/chat.service.ts
+++ b/back/src/chat/chat.service.ts
@@ -1,37 +1,20 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import { Server } from 'socket.io';
 import Socket from '@type/socket';
+import type { Server } from '@type/server';
 
 @Injectable()
 export class ChatService {
 	server: Server;
-	clientMap: Map<number, string[]> = new Map();
 
-	addSocket(socket: Socket) {
-		if (!this.clientMap.has(socket.user.id)) this.clientMap.set(socket.user.id, [socket.id]);
-		else this.clientMap.get(socket.user.id).push(socket.id);
+	async fetchSockets(userId: number) {
+		const sockets = await this.server.in(`user:${userId}`).fetchSockets();
+		return { sockets, socketIds: sockets.map((socket) => socket.id) };
 	}
 
-	removeSocket(socket: Socket) {
-		if (this.clientMap.has(socket.user.id)) {
-			const sockets: string[] = this.clientMap.get(socket.user.id).filter((s: string) => s !== socket.id);
-			if (sockets.length === 0) this.clientMap.delete(socket.user.id);
-			else this.clientMap.set(socket.user.id, sockets);
-		}
-	}
-
-	onConnection(socket: Socket) {
-		this.addSocket(socket);
-		console.log(`${socket.user.username}: `, this.clientMap.get(socket.user.id));
-	}
-
-	onDisconnection(socket: Socket) {
-		this.removeSocket(socket);
-		console.log(`${socket.user.username}: `, this.clientMap.get(socket.user.id));
-	}
-
-	emitToUser(userId: number, event: string, data: any): void {
-		if (this.clientMap.has(userId)) this.server.to(this.clientMap.get(userId)).emit(event, data);
+	async onConnection(socket: Socket) {
+		socket.join(`user:${socket.user.id}`);
+		const { socketIds } = await this.fetchSockets(socket.user.id);
+		console.log(`${socket.user.username} (onConnection): `, socketIds);
 	}
 
 	emit(event: string, data: any, rooms?: string | string[]) {
@@ -39,13 +22,19 @@ export class ChatService {
 		else this.server.emit(event, data);
 	}
 
-	joinRoom(socket_id: string, room: string) {
-		const socket: Socket = (this.server.sockets as any as Map<string, Socket>).get(socket_id);
+	emitToUser(userId: number, event: string, data: any): void {
+		this.emit(event, data, `user:${userId}`);
+	}
 
-		if (!socket) throw new BadRequestException(`Socket ${socket_id} not found.`);
+	joinRoom(socketId: string, room: string) {
+		const socket: Socket = this.server.sockets.get(socketId);
+
+		if (!socket) {
+			throw new BadRequestException(`Socket ${socketId} not found.`);
+		}
 
 		for (const room of socket.rooms) {
-			if (room === socket.id) continue;
+			if (room && (room === socket.id || room.startsWith('user:'))) continue;
 			socket.leave(room);
 		}
 

--- a/back/src/types/server.d.ts
+++ b/back/src/types/server.d.ts
@@ -1,0 +1,4 @@
+import { Server as IoServer } from 'socket.io';
+import Socket from '@type/socket';
+
+export declare type Server = IoServer & { sockets: Map<string, Socket> };


### PR DESCRIPTION
In this pull request, I have implemented the proposed changes outlined in issue #58  The key changes include:

- Replaced the use of a `Map` to associate `userId` with a list of `socketId` instances with Socket.IO rooms.
- Implemented the `fetchSockets` method to efficiently retrieve all active sockets for a specific user using ``server.in(`user:${id}`).fetchSockets()``.
- Updated the `onConnection` method to join the room `user:${socket.user.id}` when a new connection is established.
- Updated the `emitToUser` method to emit events to the user-specific room instead of managing socket IDs.

These changes simplify user socket management and improve code simplicity, readability, and performance.

Close #58 