### PR TITLE
FIX 500 ERROR (PASSPORT 42):

### DIFF
--- a/back/src/auth/auth.controller.ts
+++ b/back/src/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import type { Request } from '@type/request';
 import { User } from '@prisma/client';
 import authConfig from '@config/auth.config';
 import { UserService } from '@user/user.service';
+import { ftGuard } from '@guard/fortyTwo.guard';
 
 @Controller('auth')
 export class AuthController {
@@ -16,7 +17,7 @@ export class AuthController {
 	) {}
 
 	@Get('login')
-	@UseGuards(AuthGuard('42'))
+	@UseGuards(ftGuard)
 	async login() {}
 
 	@Get('logout')
@@ -25,7 +26,7 @@ export class AuthController {
 	}
 
 	@Get('callback')
-	@UseGuards(AuthGuard('42'))
+	@UseGuards(ftGuard)
 	async callback(@Req() req: Request, @Res() res: Response) {
 		const token: { access_token: string } = await this.authService.validateUser(req.user);
 		res.cookie('access_token', token.access_token, { httpOnly: true }).redirect(authConfig.webAppURL);

--- a/back/src/guards/fortyTwo.guard.ts
+++ b/back/src/guards/fortyTwo.guard.ts
@@ -1,0 +1,10 @@
+import { AuthGuard } from '@nestjs/passport';
+import { UnauthorizedException } from '@nestjs/common';
+import { User } from '@prisma/client';
+
+export class ftGuard extends AuthGuard('42') {
+	handleRequest<TUser = User>(err: Error, user: TUser) {
+		if (err) throw new UnauthorizedException('Cannot log in with 42.', { description: err.message });
+		return user;
+	}
+}


### PR DESCRIPTION
Add a FtGuard extending AuthGuard('42') to handle request and catch some errors avoiding 500 errors (if secrets expired, bad code param etc).