### PR TITLE
FIX JOIN CHANNEL:

### DIFF
--- a/back/src/chat/channel/channel.service.ts
+++ b/back/src/chat/channel/channel.service.ts
@@ -178,9 +178,11 @@ export class ChannelService {
 				});
 			case ChannelRole.INVITED:
 				channelConnection = await this.updateChannelRole(ChannelRole.DEFAULT, targetChannelId, user.id);
-				this.chatService.joinRoom(socketId, targetChannelId.toString());
-				this.chatService.emit('chat:join', channelConnection, targetChannelId.toString());
+				break;
 		}
+
+		this.chatService.joinRoom(socketId, targetChannelId.toString());
+		this.chatService.emit('chat:join', channelConnection, targetChannelId.toString());
 		return channelConnection;
 	}
 


### PR DESCRIPTION
Fix the joinChannel method.
If the user already has a connection but weren't invited, the joinRoom method was not called so the user was not receiving new ws event of the current channel.