### PR TITLE
MERGE RELATIONS FRONTEND:

### DIFF
--- a/back/src/relationship/relationship.controller.ts
+++ b/back/src/relationship/relationship.controller.ts
@@ -14,25 +14,44 @@ import { AuthenticatedGuard } from '@guard/authenticated.guard';
 import { RelationshipService } from './relationship.service';
 import type { Request } from '@type/request';
 import { Relationship } from '@prisma/client';
+import { StatusService } from '@user/status/status.service';
 
 @Controller('relationship')
 @UseGuards(...AuthenticatedGuard)
 export class RelationshipController {
-	constructor(private readonly relationshipService: RelationshipService) {}
+	constructor(
+		private readonly relationshipService: RelationshipService,
+		private statusService: StatusService
+	) {}
 
 	@Get()
 	async getAll(@Req() req: Request): Promise<Relationship[]> {
-		return await this.relationshipService.getAll(req.user.id);
+		const relations = await this.relationshipService.getAll(req.user.id);
+		const statuses = await this.statusService.getByUserIds(relations.map((relation) => relation.receiverId));
+		return relations.map((relation, index) => ({
+			...relation,
+			...statuses[index]
+		}));
 	}
 
 	@Get('friends')
 	async getAllFriends(@Req() req: Request): Promise<Relationship[]> {
-		return await this.relationshipService.getAllFriends(req.user.id);
+		const friends = await this.relationshipService.getAllFriends(req.user.id);
+		const statuses = await this.statusService.getByUserIds(friends.map((relation) => relation.receiverId));
+		return friends.map((relation, index) => ({
+			...relation,
+			...statuses[index]
+		}));
 	}
 
 	@Get('blocked')
 	async getAllBlocked(@Req() req: Request): Promise<Relationship[]> {
-		return await this.relationshipService.getAllBlocked(req.user.id);
+		const blocked = await this.relationshipService.getAllBlocked(req.user.id);
+		const statuses = await this.statusService.getByUserIds(blocked.map((relation) => relation.receiverId));
+		return blocked.map((relation, index) => ({
+			...relation,
+			...statuses[index]
+		}));
 	}
 
 	@Get(':id')

--- a/back/src/relationship/relationship.module.ts
+++ b/back/src/relationship/relationship.module.ts
@@ -3,9 +3,10 @@ import { PrismaModule } from '@prisma/prisma.module';
 import { AuthModule } from '@auth/auth.module';
 import { RelationshipController } from './relationship.controller';
 import { RelationshipService } from './relationship.service';
+import { StatusModule } from '@user/status/status.module';
 
 @Module({
-	imports: [AuthModule, PrismaModule],
+	imports: [AuthModule, PrismaModule, StatusModule],
 	controllers: [RelationshipController],
 	providers: [RelationshipService]
 })

--- a/back/src/relationship/relationship.module.ts
+++ b/back/src/relationship/relationship.module.ts
@@ -4,9 +4,10 @@ import { AuthModule } from '@auth/auth.module';
 import { RelationshipController } from './relationship.controller';
 import { RelationshipService } from './relationship.service';
 import { StatusModule } from '@user/status/status.module';
+import { ChatModule } from '@chat/chat.module';
 
 @Module({
-	imports: [AuthModule, PrismaModule, StatusModule],
+	imports: [AuthModule, PrismaModule, ChatModule, StatusModule],
 	controllers: [RelationshipController],
 	providers: [RelationshipService]
 })

--- a/back/src/relationship/relationship.service.ts
+++ b/back/src/relationship/relationship.service.ts
@@ -47,7 +47,8 @@ export class RelationshipService {
 					receiverId: targetId,
 					kind: RelationKind.FRIEND
 				},
-				update: { kind: RelationKind.FRIEND }
+				update: { kind: RelationKind.FRIEND },
+				include: { receiver: true }
 			})
 			.catch(() => {
 				throw new BadRequestException('Cannot add user as friend', {
@@ -67,7 +68,8 @@ export class RelationshipService {
 					receiverId: targetId,
 					kind: RelationKind.BLOCKED
 				},
-				update: { kind: RelationKind.BLOCKED }
+				update: { kind: RelationKind.BLOCKED },
+				include: { receiver: true }
 			})
 			.catch(() => {
 				throw new BadRequestException('Cannot block user', {
@@ -81,7 +83,8 @@ export class RelationshipService {
 			.delete({
 				where: {
 					relationshipId: { senderId: userId, receiverId: targetId }
-				}
+				},
+				include: { receiver: true }
 			})
 			.catch(() => {
 				throw new BadRequestException('Cannot remove relationship', {

--- a/back/src/relationship/relationship.service.ts
+++ b/back/src/relationship/relationship.service.ts
@@ -7,35 +7,37 @@ export class RelationshipService {
 	constructor(private prisma: PrismaService) {}
 
 	async getAll(userId: number): Promise<Relationship[]> {
-		return await this.prisma.relationship.findMany({
+		return this.prisma.relationship.findMany({
 			where: { senderId: userId }
 		});
 	}
 
 	async getAllFriends(userId: number): Promise<Relationship[]> {
-		return await this.prisma.relationship.findMany({
+		return this.prisma.relationship.findMany({
 			where: {
 				AND: [{ senderId: userId }, { kind: RelationKind.FRIEND }]
-			}
+			},
+			include: { receiver: true }
 		});
 	}
 
 	async getAllBlocked(userId: number): Promise<Relationship[]> {
-		return await this.prisma.relationship.findMany({
+		return this.prisma.relationship.findMany({
 			where: {
 				AND: [{ senderId: userId }, { kind: RelationKind.BLOCKED }]
-			}
+			},
+			include: { receiver: true }
 		});
 	}
 
 	async getStatus(userId: number, targetId: number): Promise<Relationship> {
-		return await this.prisma.relationship.findUnique({
+		return this.prisma.relationship.findUnique({
 			where: { relationshipId: { senderId: userId, receiverId: targetId } }
 		});
 	}
 
 	async add(userId: number, targetId: number): Promise<Relationship> {
-		return await this.prisma.relationship
+		return this.prisma.relationship
 			.upsert({
 				where: {
 					relationshipId: { senderId: userId, receiverId: targetId }
@@ -55,7 +57,7 @@ export class RelationshipService {
 	}
 
 	async block(userId: number, targetId: number): Promise<Relationship> {
-		return await this.prisma.relationship
+		return this.prisma.relationship
 			.upsert({
 				where: {
 					relationshipId: { senderId: userId, receiverId: targetId }
@@ -75,7 +77,7 @@ export class RelationshipService {
 	}
 
 	async remove(userId: number, targetId: number): Promise<Relationship> {
-		return await this.prisma.relationship
+		return this.prisma.relationship
 			.delete({
 				where: {
 					relationshipId: { senderId: userId, receiverId: targetId }

--- a/back/src/user/status/status.service.ts
+++ b/back/src/user/status/status.service.ts
@@ -11,4 +11,8 @@ export class StatusService {
 		const status = socketIds.length > 0 ? 'online' : 'offline';
 		return { status };
 	}
+
+	async getByUserIds(ids: number[]) {
+		return await Promise.all(ids.map((id: number) => this.getByUserId(id)));
+	}
 }

--- a/front/components/chat/box.vue
+++ b/front/components/chat/box.vue
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { Relationship } from "~/types/relation";
+
 interface IMessage {
   size: number;
   message: string;
@@ -14,6 +16,17 @@ export default defineNuxtComponent({
   mounted() {
     this.$chat.currentConnections();
     this.$chat.currentRelationships();
+    this.socket.on('relation:update', (data: Relationship) => {
+      this.$chat.updateRelationship(data);
+    });
+    this.socket.on('relation:remove', (data: Relationship) => {
+      this.$chat.removeRelationship(data);
+    });
+  },
+
+  unmounted() {
+    this.socket.off('relation:update');
+    this.socket.off('relation:remove');
   },
 
   methods: {
@@ -46,7 +59,7 @@ h2 {
 .chatBox {
   width: 100%;
   height: 100%;
-  gap: 0.rem;
+  gap: 0.1rem;
   max-height: calc(100vh - 4rem);
   overflow: hidden;
   display: flex;

--- a/front/components/profile/profile.vue
+++ b/front/components/profile/profile.vue
@@ -62,13 +62,19 @@ export default defineNuxtComponent({
           <v-tabs v-model="tab" class="w-100">
             <v-tab>Stats</v-tab>
             <v-tab>Games</v-tab>
-            <v-tab v-if="!this.editable()">Social</v-tab>
+            <v-tab>Social</v-tab>
           </v-tabs>
           <v-window v-model="tab" class="my-4">
             <v-window-item> Stats </v-window-item>
             <v-window-item> Games </v-window-item>
-            <v-window-item v-if="!this.editable()">
-              <ProfileSocial :user="this.user" />
+            <v-window-item>
+              <div v-if="!this.editable()">
+                <ProfileSocial :user="this.user" />
+              </div>
+              <div v-else class="d-flex flex-row flex-wrap" style="gap: 1rem;">
+                <ProfileRelations kind="Friends" class="flex-grow-1" style="flex-basis: 325px;" />
+                <ProfileRelations kind="Blocked" class="flex-grow-1" style="flex-basis: 325px;" />
+              </div>
             </v-window-item>
           </v-window>
         </div>

--- a/front/components/profile/profile.vue
+++ b/front/components/profile/profile.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 import type { User } from '~/types/user';
-import { Relationship } from "~/types/relation";
 
 enum Status {
   OFFLINE = 'offline',
@@ -61,22 +60,22 @@ export default defineNuxtComponent({
         <v-divider thickness="3" class='my-5 w-100'></v-divider>
         <div class="d-flex w-100" style="flex-direction: column">
           <v-tabs v-model="tab" class="w-100">
+            <v-tab>Social</v-tab>
             <v-tab>Stats</v-tab>
             <v-tab>Games</v-tab>
-            <v-tab>Social</v-tab>
           </v-tabs>
           <v-window v-model="tab" class="my-4">
-            <v-window-item> Stats </v-window-item>
-            <v-window-item> Games </v-window-item>
             <v-window-item>
               <div v-if="!this.editable()">
-                <ProfileSocial :user="this.user" />
+                <ProfileSocial :socket="this.socket" :user="this.user" />
               </div>
               <div v-else class="d-flex flex-row flex-wrap" style="gap: 1rem;">
                 <ProfileRelations :socket="this.socket" kind="Friends" class="flex-grow-1" style="flex-basis: 325px;" />
                 <ProfileRelations :socket="this.socket" kind="Blocked" class="flex-grow-1" style="flex-basis: 325px;" />
               </div>
             </v-window-item>
+            <v-window-item> Stats </v-window-item>
+            <v-window-item> Games </v-window-item>
           </v-window>
         </div>
 

--- a/front/components/profile/profile.vue
+++ b/front/components/profile/profile.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { User } from '~/types/user';
+import { Relationship } from "~/types/relation";
 
 enum Status {
   OFFLINE = 'offline',
@@ -73,7 +74,7 @@ export default defineNuxtComponent({
               </div>
               <div v-else class="d-flex flex-row flex-wrap" style="gap: 1rem;">
                 <ProfileRelations :socket="this.socket" kind="Friends" class="flex-grow-1" style="flex-basis: 325px;" />
-                <ProfileRelations kind="Blocked" class="flex-grow-1" style="flex-basis: 325px;" />
+                <ProfileRelations :socket="this.socket" kind="Blocked" class="flex-grow-1" style="flex-basis: 325px;" />
               </div>
             </v-window-item>
           </v-window>

--- a/front/components/profile/profile.vue
+++ b/front/components/profile/profile.vue
@@ -10,8 +10,9 @@ enum Status {
 export default defineNuxtComponent({
   props: ['id', 'socket'],
   data: () => ({
-    user: null as User | null,
-    status: Status.OFFLINE
+    user: null as User & { status: Status } | null,
+    status: Status.OFFLINE,
+    tab: 0,
   }),
   async beforeMount() {
     const data = await this.$api.get(`/user/${this.id}`);
@@ -21,7 +22,7 @@ export default defineNuxtComponent({
       return ;
     }
     this.user = data;
-    this.status = this.user.status;
+    this.status = this.user!.status;
     this.socket.on(`user:${this.id}:status`, (data: { status: Status }) => {
       this.status = data.status;
     });
@@ -33,7 +34,7 @@ export default defineNuxtComponent({
     editable() {
       return this.user && this.user.id === this.$auth.user.id;
     },
-    onUpdateUser(user: User) {
+    onUpdateUser(user: User & { status: Status }) {
       this.user = user;
     },
     getStatusColor() {
@@ -56,6 +57,22 @@ export default defineNuxtComponent({
         <ProfileAvatar :user="this.user" :editable="this.editable()" @user:updated="this.onUpdateUser" />
         <ProfileUsername :user="this.user" :editable="this.editable()" @user:updated="this.onUpdateUser" />
         <p :style="{'color': this.getStatusColor()}">{{ this.status }}</p>
+        <v-divider thickness="3" class='my-5 w-100'></v-divider>
+        <div class="d-flex w-100" style="flex-direction: column">
+          <v-tabs v-model="tab" class="w-100">
+            <v-tab>Stats</v-tab>
+            <v-tab>Games</v-tab>
+            <v-tab v-if="!this.editable()">Social</v-tab>
+          </v-tabs>
+          <v-window v-model="tab" class="my-4">
+            <v-window-item> Stats </v-window-item>
+            <v-window-item> Games </v-window-item>
+            <v-window-item v-if="!this.editable()">
+              <ProfileSocial :user="this.user" />
+            </v-window-item>
+          </v-window>
+        </div>
+
       </div>
     </div>
     <div v-else class="d-flex w-100 h-100">

--- a/front/components/profile/profile.vue
+++ b/front/components/profile/profile.vue
@@ -72,7 +72,7 @@ export default defineNuxtComponent({
                 <ProfileSocial :user="this.user" />
               </div>
               <div v-else class="d-flex flex-row flex-wrap" style="gap: 1rem;">
-                <ProfileRelations kind="Friends" class="flex-grow-1" style="flex-basis: 325px;" />
+                <ProfileRelations :socket="this.socket" kind="Friends" class="flex-grow-1" style="flex-basis: 325px;" />
                 <ProfileRelations kind="Blocked" class="flex-grow-1" style="flex-basis: 325px;" />
               </div>
             </v-window-item>

--- a/front/components/profile/relations.vue
+++ b/front/components/profile/relations.vue
@@ -1,0 +1,88 @@
+<script lang='ts'>
+import { Relationship } from '~/types/relation';
+
+export default defineNuxtComponent({
+  props: ["kind"],
+  data: () => ({
+    connectionsList: null as Relationship[] | null,
+    loading: true,
+  }),
+  beforeMount() {
+    this.fetchRelations();
+  },
+  methods: {
+    getIcon() {
+      return this.kind === 'Blocked' ? 'mdi-account-off' : 'mdi-account-group';
+    },
+    getInfoMessage() {
+      return this.kind === 'Blocked' ? 'You have no blocked users' : 'You have no friends';
+    },
+    async fetchRelations() {
+      this.loading = true;
+      this.connectionsList = await this.$api.get(`/relationship/${this.kind.toLowerCase()}`);
+      console.log(this.connectionsList);
+      this.loading = false;
+    },
+    async onDelete(connectionId: number) {
+      this.$api.delete(`/relationship/${connectionId}`);
+      this.connectionsList = this.connectionsList!.filter((connection) => connection.receiverId !== connectionId);
+    }
+  }
+})
+</script>
+
+<template>
+  <v-card width="100%" class="overflow-hidden" :prepend-icon="this.getIcon()">
+    <template v-slot:title>
+      {{ this.kind }}
+    </template>
+    <div v-if="this.loading" class="w-100 pb-4">
+      <div class="mx-auto d-flex flex-column">
+        <v-progress-circular class="mx-auto" indeterminate size="75" color="primary" />
+        <h4 class="mx-auto">Loading...</h4>
+      </div>
+    </div>
+    <div v-else-if="this.connectionsList === undefined" class="d-flex flex-column w-100 pb-4 px-4">
+      <v-alert type="error" color="red" icon="mdi-alert">
+        <span class="mx-auto">Woops something went wrong</span>
+      </v-alert>
+    </div>
+    <div v-else class="relations-content overflow-auto">
+      <div v-if="this.connectionsList.length === 0" class="d-flex flex-column w-100">
+        <v-alert type="info" color="blue" icon="mdi-information">
+          <span class="mx-auto">{{ this.getInfoMessage() }}</span>
+        </v-alert>
+      </div>
+      <v-list v-else>
+        <v-list-item v-for="connection of this.connectionsList" :key="connection.receiverId">
+          <template v-slot:prepend>
+            <v-avatar :image="connection.receiver.avatar" />
+          </template>
+          <div class='d-flex flex-row'>
+            <v-list-item-title>
+              {{ connection.receiver.username }}
+            </v-list-item-title>
+            <v-spacer />
+            <div v-if="this.kind === 'Friends'">
+              <v-icon color="red" @click.prevent="this.onDelete(connection.receiverId)" class="mx-2">mdi-minus</v-icon>
+            </div>
+            <div v-else>
+              <v-icon color="red" @click.prevent="this.onDelete(connection.receiverId)" class="mx-2">mdi-minus</v-icon>
+            </div>
+          </div>
+        </v-list-item>
+      </v-list>
+    </div>
+  </v-card>
+</template>
+
+<style scoped>
+.relations-content {
+  display: flex;
+  flex-direction: column;
+  padding: 0 1rem 1rem 1rem;
+  height: 100%;
+  max-height: 20rem;
+  overflow: auto;
+}
+</style>

--- a/front/components/profile/relations.vue
+++ b/front/components/profile/relations.vue
@@ -9,23 +9,20 @@ export default defineNuxtComponent({
   }),
   async beforeMount() {
     await this.fetchRelations();
-    if (this.socket) {
-      this.socket.on('relation:update', (data: Relationship) => {
-        if (data.kind === this.getKind())
-          this.addRelation(data);
-        else
-          this.removeRelation(data);
-      });
-      this.socket.on(['relation:remove'], (data: { receiverId: number }) => {
+    this.socket.on('relation:update', (data: Relationship) => {
+      if (data.kind === this.getKind())
+        this.addRelation(data);
+      else
         this.removeRelation(data);
-      });
-    }
+    });
+    this.socket.on(['relation:remove'], (data: { receiverId: number }) => {
+      this.removeRelation(data);
+    });
   },
   unmounted() {
     for (const connection of this.connectionsList!) {
       this.removeWsHook(connection);
     }
-    if (!this.socket) return;
     this.socket.off('relation:update');
     this.socket.off('relation:remove');
   },
@@ -115,7 +112,7 @@ export default defineNuxtComponent({
         </v-alert>
       </div>
       <v-list v-else>
-        <v-list-item v-for="(connection, i) in this.connectionsList" :list="connection">
+        <v-list-item v-for="connection in this.connectionsList" :list="connection">
           <template v-slot:prepend>
             <v-avatar :image="connection.receiver.avatar" />
           </template>
@@ -133,10 +130,7 @@ export default defineNuxtComponent({
               </div>
             </v-list-item-title>
             <v-spacer />
-            <div v-if="this.kind === 'Friends'">
-              <v-icon color="red" @click.prevent="this.onDelete(connection.receiverId)" class="mx-2">mdi-minus</v-icon>
-            </div>
-            <div v-else>
+            <div>
               <v-icon color="red" @click.prevent="this.onDelete(connection.receiverId)" class="mx-2">mdi-minus</v-icon>
             </div>
           </div>

--- a/front/components/profile/relations.vue
+++ b/front/components/profile/relations.vue
@@ -47,7 +47,7 @@ export default defineNuxtComponent({
     addRelation(connection: Relationship) {
       const _i = this.connectionsList!.findIndex((c: Relationship) => c.receiverId === connection.receiverId);
       if (_i !== -1) {
-        this.connectionsList[_i] = connection;
+        this.connectionsList[_i].update(connection);
         return ;
       }
       this.connectionsList!.push(connection);
@@ -60,7 +60,8 @@ export default defineNuxtComponent({
       this.removeWsHook(this.connectionsList![_i]);
       this.connectionsList!.splice(_i, 1);
     },
-    async onDelete(connectionId: number) {
+    async onDelete(connectionId: number, e?: Event) {
+      if (e) e.stopPropagation();
       this.$api.delete(`/relationship/${connectionId}`);
     },
     sortConnections(connections: Relationship[]) {
@@ -84,6 +85,9 @@ export default defineNuxtComponent({
       if (this.socket) {
         this.socket.off(`user:${connection.receiverId}:status`);
       }
+    },
+    redirectProfile(connection: Relationship) {
+      this.$router.push(`/profile/${connection.receiverId}`);
     }
   }
 })
@@ -112,7 +116,7 @@ export default defineNuxtComponent({
         </v-alert>
       </div>
       <v-list v-else>
-        <v-list-item v-for="connection in this.connectionsList" :list="connection">
+        <v-list-item v-for="connection in this.connectionsList" :list="connection" @click="redirectProfile(connection)">
           <template v-slot:prepend>
             <v-avatar :image="connection.receiver.avatar" />
           </template>
@@ -130,8 +134,8 @@ export default defineNuxtComponent({
               </div>
             </v-list-item-title>
             <v-spacer />
-            <div>
-              <v-icon color="red" @click.prevent="this.onDelete(connection.receiverId)" class="mx-2">mdi-minus</v-icon>
+            <div class="my-auto remove-zone" @click.prevent="(e) => {this.onDelete(connection.receiverId, e)}">
+              <v-icon color="red" class="btn">mdi-minus</v-icon>
             </div>
           </div>
         </v-list-item>
@@ -156,5 +160,9 @@ export default defineNuxtComponent({
 
 .status.online {
   color: #3da73d;
+}
+.remove-zone:hover .btn {
+  background-color: #4b3434;
+  border-radius: 50%;
 }
 </style>

--- a/front/components/profile/social.vue
+++ b/front/components/profile/social.vue
@@ -9,7 +9,6 @@ export default defineNuxtComponent({
   }),
   async beforeMount() {
     await this.fetchRelation();
-    this.relation = null;
   },
   methods: {
     async fetchRelation() {

--- a/front/components/profile/social.vue
+++ b/front/components/profile/social.vue
@@ -1,7 +1,7 @@
 <script lang='ts'>
 import { Relationship, RelationKind } from '~/types/relation';
 export default defineNuxtComponent({
-  props: ["user"],
+  props: ["user", "socket"],
   data: () => ({
     relation: null as Relationship | null,
     loading: false,
@@ -9,6 +9,20 @@ export default defineNuxtComponent({
   }),
   async beforeMount() {
     await this.fetchRelation();
+    if (!this.socket) return;
+    this.socket.on('relation:update', (data: Relationship) => {
+      if (this.user.id === data.receiverId)
+        this.relation = data;
+    });
+    this.socket.on('relation:remove', (data: Relationship) => {
+      if (this.user.id === data.receiverId)
+        this.relation = null;
+    });
+  },
+  unmounted() {
+    if (!this.socket) return;
+    this.socket.off('relation:update');
+    this.socket.off('relation:remove');
   },
   methods: {
     async fetchRelation() {

--- a/front/components/profile/social.vue
+++ b/front/components/profile/social.vue
@@ -1,0 +1,83 @@
+<script lang='ts'>
+import { Relationship, RelationKind } from '~/types/relation';
+export default defineNuxtComponent({
+  props: ["user"],
+  data: () => ({
+    relation: null as Relationship | null,
+    loading: false,
+    RelationKind,
+  }),
+  async beforeMount() {
+    await this.fetchRelation();
+    this.relation = null;
+  },
+  methods: {
+    async fetchRelation() {
+      this.loading = true;
+      this.relation = await this.$api.get('/relationship/' + this.user.id);
+      this.loading = false;
+    },
+    canAddFriend() {
+      return !this.relation || this.relation.kind === RelationKind.BLOCKED;
+    },
+    async onAddFriend() {
+      this.relation = await this.$api.post(`/relationship/${this.user.id}/add`);
+    },
+    async onBlock() {
+      this.relation = await this.$api.post(`/relationship/${this.user.id}/block`);
+    },
+    async onDelete() {
+      this.relation = await this.$api.delete(`/relationship/${this.user.id}`);
+      if (this.relation)
+        this.relation = '';
+    }
+  }
+})
+</script>
+
+<template>
+  <v-card width="100%" class="overflow-visible" prepend-icon="mdi-account-group">
+    <template v-slot:title>
+      Social
+    </template>
+    <div v-if="!this.loading && this.relation !== undefined" class="friends-content">
+      <v-btn v-if="this.canAddFriend()" class="mx-auto" color="primary" @click.prevent="this.onAddFriend" prepend-icon="mdi-account-plus">
+        Add to friends
+      </v-btn>
+      <v-btn v-else-if="this.relation && this.relation.kind === this.RelationKind.FRIEND" color="red" @click.prevent="this.onDelete" prepend-icon="mdi-account-minus">
+        Remove friend
+      </v-btn>
+      <v-btn v-if="this.relation && this.relation.kind === this.RelationKind.BLOCKED" class="ml-2" color="red" @click.prevent="this.onDelete" prepend-icon="mdi-account-check">
+        Unblock
+      </v-btn>
+      <v-btn v-else class="ml-2" color="primary" @click.prevent="this.onBlock" prepend-icon="mdi-account-off">
+        Block
+      </v-btn>
+    </div>
+    <div v-else-if="this.loading" class="w-100 pb-4">
+      <div class="mx-auto d-flex flex-column">
+        <v-progress-circular class="mx-auto" indeterminate size="75" color="primary" />
+        <h4 class="mx-auto">Loading...</h4>
+      </div>
+    </div>
+    <div v-else class="d-flex flex-column w-100 pb-4 px-4">
+      <v-alert type="error" color="red" icon="mdi-alert">
+        <span class="mx-auto">Woops something went wrong</span>
+        <v-icon class="reload-btn mx-2" @click="this.fetchRelation">mdi-reload</v-icon>
+      </v-alert>
+    </div>
+  </v-card>
+</template>
+
+<style scoped>
+.friends-content {
+  padding: 0 1rem 1rem 1rem;
+  gap: 10px;
+}
+.reload-btn {
+  cursor: pointer;
+}
+.reload-btn:hover {
+  color: #f0c1c1;
+}
+</style>

--- a/front/stores/chat.store.ts
+++ b/front/stores/chat.store.ts
@@ -34,12 +34,12 @@ export const useChatStore = defineStore('chat', {
 			const config = useRuntimeConfig();
 			const currentConnections = await $fetch<IChannelConnection[]>(`${config.app.API_URL}/chat/channel/connection`, {
 				credentials: 'include'
-			}).catch((err) => {
+			}).catch((err: any) => {
 				console.log(err.response._data.message);
 			})
 			if (currentConnections)
 			{
-				this.channelConnections = new Map(currentConnections.map(connection => [connection.channelId, connection]))
+				this.channelConnections = new Map(currentConnections.map((connection: IChannelConnection) => [connection.channelId, connection]))
 				console.log(this.channelConnections);
 			}
 		},
@@ -48,13 +48,19 @@ export const useChatStore = defineStore('chat', {
 			const config = useRuntimeConfig();
 			const currentRelationships = await $fetch<IRelationship[]>(`${config.app.API_URL}/relationship`, {
 				credentials: 'include'
-			}).catch((err) => {
+			}).catch((err: any) => {
 				console.log(err.response._data.message);
 			})
 			if (currentRelationships)
 			{
-				this.relationships = new Map(currentRelationships.map(relationship => [relationship.senderId, relationship]))			
+				this.relationships = new Map(currentRelationships.map((relationship: IRelationship) => [relationship.receiverId, relationship]))
 			}
+		},
+		async updateRelationship (relationship: IRelationship) {
+			this.relationships.set(relationship.receiverId, relationship);
+		},
+		async removeRelationship (relationship: IRelationship) {
+			this.relationships.delete(relationship.receiverId);
 		}
 	}
 })

--- a/front/types/relation.ts
+++ b/front/types/relation.ts
@@ -1,0 +1,10 @@
+export enum RelationKind {
+	FRIEND = 'FRIEND',
+	BLOCKED = 'BLOCKED'
+}
+
+export interface Relationship {
+	senderId: number;
+	receiverId: number;
+	kind: RelationKind;
+}

--- a/front/types/relation.ts
+++ b/front/types/relation.ts
@@ -1,3 +1,5 @@
+import type { User } from './user';
+
 export enum RelationKind {
 	FRIEND = 'FRIEND',
 	BLOCKED = 'BLOCKED'
@@ -7,4 +9,6 @@ export interface Relationship {
 	senderId: number;
 	receiverId: number;
 	kind: RelationKind;
+	status: string;
+	receiver: User;
 }


### PR DESCRIPTION
Add a social component to manage relations on profile page.

Add 2 new ws events: `relation:update` and `relation:remove` to manage relations in real time.
The event relation:update is send when a relation is updated or newly created.
The event relation:remove is send when a relation is removed.

The 'social' component allows you to manage your friends and blocked users if you're on your own profile, otherwise you can add or block the person whose profile you're visiting.

Everything works in real-time through web sockets