### PR TITLE
ADD MUTE TIME HANDLED FROM BACK:

### DIFF
--- a/back/src/chat/channel/channel.controller.ts
+++ b/back/src/chat/channel/channel.controller.ts
@@ -12,7 +12,7 @@ import {
 	UsePipes
 } from '@nestjs/common';
 
-import { ChannelCreationDto, ChannelDto, ChannelPasswordDto } from '@type/channel.dto';
+import { ChannelCreationDto, ChannelDto, ChannelPasswordDto, MuteTimeDto } from '@type/channel.dto';
 import type { Request } from '@type/request';
 import { AuthenticatedGuard } from '@guard/authenticated.guard';
 import { ChannelService } from './channel.service';
@@ -169,9 +169,9 @@ export class ChannelController {
 		@Param('targetChannelId', ParseIntPipe) channelId: number,
 		@Req() req: Request,
 		@Param('targetUserId', ParseIntPipe) targetUserId: number,
-		@Body() muteTime: Date
+		@Body() muteTime: MuteTimeDto
 	) {
-		return await this.channelService.mute(req.user, channelId, targetUserId, muteTime);
+		return await this.channelService.mute(req.user, channelId, targetUserId, muteTime.time);
 	}
 
 	@Post(':targetChannelId/mute/:targetUserId')

--- a/back/src/chat/channel/channel.service.ts
+++ b/back/src/chat/channel/channel.service.ts
@@ -618,7 +618,7 @@ export class ChannelService {
 		return demotedUser;
 	}
 
-	async mute(user: User, targetChannelId: number, targetUserId: number, time: Date): Promise<ChannelConnection> {
+	async mute(user: User, targetChannelId: number, targetUserId: number, time: number): Promise<ChannelConnection> {
 		if (await this.isUserOwnerInChannel(targetUserId, targetChannelId)) {
 			throw new ForbiddenException('Cannot mute user', {
 				description: 'Cannot mute the owner'
@@ -629,12 +629,14 @@ export class ChannelService {
 				description: 'You did not specify a time'
 			});
 		}
+		let date = new Date();
+		date = new Date(date.setMinutes(date.getMinutes() + time));
 		const mutedUser = await this.prisma.channelConnection
 			.update({
 				where: {
 					connectionId: { userId: targetUserId, channelId: targetChannelId }
 				},
-				data: { muted: time }
+				data: { muted: date }
 			})
 			.catch(() => {
 				throw new BadRequestException('Cannot mute user', {

--- a/back/src/game/game.service.ts
+++ b/back/src/game/game.service.ts
@@ -120,20 +120,20 @@ export class GameService extends BroadcastService {
 	   }
 	*/
 	async getStats(userId: number): Promise<GameStats> {
-		const gameWon = await this.getGameNbByResult(userId, GameState.WON);
-		const gameLost = await this.getGameNbByResult(userId, GameState.LOST);
-		const gameDrawn = await this.getGameNbByResult(userId, GameState.DRAW);
-		const gameNb = gameWon + gameLost + gameDrawn;
+		const gameWon: number = await this.getGameNbByResult(userId, GameState.WON);
+		const gameLost: number = await this.getGameNbByResult(userId, GameState.LOST);
+		const gameDrawn: number = await this.getGameNbByResult(userId, GameState.DRAW);
+		const gameNb: number = gameWon + gameLost + gameDrawn;
 
-		const goalTaken = await this.getGoalTaken(userId);
-		const goalScored = await this.getGoalScored(userId);
+		const goalTaken: number = await this.getGoalTaken(userId);
+		const goalScored: number = await this.getGoalScored(userId);
 
 		return {
 			gameNb: gameNb,
 			wonNb: gameWon,
 			lostNb: gameLost,
 			drawNb: gameDrawn,
-			winRatio: gameNb === 0 ? 0 : (gameWon / gameNb) * 100,
+			winRatio: gameNb === 0 ? 0 : Math.round((gameWon / gameNb) * 100),
 			goalScored: 0,
 			goalTaken: 0,
 			goalRatio: goalTaken === 0 ? goalScored : parseFloat(((goalScored / goalTaken) * 100).toFixed(2))

--- a/back/src/types/channel.dto.ts
+++ b/back/src/types/channel.dto.ts
@@ -7,7 +7,9 @@ import {
 	NotEquals,
 	Equals,
 	ValidateIf,
-	Length
+	Length,
+	Min,
+	Max
 } from 'class-validator';
 
 import { ChannelKind } from '@prisma/client';
@@ -78,4 +80,12 @@ export class ChannelPasswordDto {
 
 	@IsString()
 	socketId: string;
+}
+
+export class MuteTimeDto {
+	@IsNotEmpty()
+	@IsNumber()
+	@Min(0)
+	@Max(1728)
+	time: number;
 }


### PR DESCRIPTION
Dealing with mute time in the backend.
Now accepting a number.

Using a MuteTimeDto that allows a mute time from 0 to 1728min (72h).

Setting to 0 will unmute the user, setting to more will mute

Also added a small fix in preparation for the stats page.