### PR TITLE
MERGE PRIVMSG EVENTS:

### DIFF
--- a/back/prisma/migrations/20231009165910_initial/migration.sql
+++ b/back/prisma/migrations/20231009165910_initial/migration.sql
@@ -129,22 +129,22 @@ CREATE UNIQUE INDEX "GameRecord_gameId_position_key" ON "GameRecord"("gameId", "
 CREATE UNIQUE INDEX "Game_id_key" ON "Game"("id");
 
 -- AddForeignKey
-ALTER TABLE "Relationship" ADD CONSTRAINT "Relationship_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Relationship" ADD CONSTRAINT "Relationship_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Relationship" ADD CONSTRAINT "Relationship_receiverId_fkey" FOREIGN KEY ("receiverId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Relationship" ADD CONSTRAINT "Relationship_receiverId_fkey" FOREIGN KEY ("receiverId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "ChannelConnection" ADD CONSTRAINT "ChannelConnection_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "ChannelConnection" ADD CONSTRAINT "ChannelConnection_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "ChannelConnection" ADD CONSTRAINT "ChannelConnection_channelId_fkey" FOREIGN KEY ("channelId") REFERENCES "Channel"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "ChannelConnection" ADD CONSTRAINT "ChannelConnection_channelId_fkey" FOREIGN KEY ("channelId") REFERENCES "Channel"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Message" ADD CONSTRAINT "Message_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Message" ADD CONSTRAINT "Message_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "Message" ADD CONSTRAINT "Message_channelId_fkey" FOREIGN KEY ("channelId") REFERENCES "Channel"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Message" ADD CONSTRAINT "Message_channelId_fkey" FOREIGN KEY ("channelId") REFERENCES "Channel"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "Otp" ADD CONSTRAINT "Otp_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/back/prisma/schema.prisma
+++ b/back/prisma/schema.prisma
@@ -8,8 +8,8 @@ datasource db {
 }
 
 model Relationship {
-  sender     User          @relation("senderRelation", fields: [senderId], references: [id])
-  receiver   User          @relation("receiverRelation", fields: [receiverId], references: [id])
+  sender     User          @relation("senderRelation", fields: [senderId], references: [id], onDelete: Cascade)
+  receiver   User          @relation("receiverRelation", fields: [receiverId], references: [id], onDelete: Cascade)
   senderId   Int
   receiverId Int
   kind       RelationKind?
@@ -27,8 +27,8 @@ model Channel {
 }
 
 model ChannelConnection {
-  user      User        @relation(fields: [userId], references: [id])
-  channel   Channel     @relation(fields: [channelId], references: [id])
+  user      User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  channel   Channel     @relation(fields: [channelId], references: [id], onDelete: Cascade)
   userId    Int
   channelId Int
   role      ChannelRole
@@ -39,10 +39,10 @@ model ChannelConnection {
 
 model Message {
   id        Int      @id @default(autoincrement())
-  user      User     @relation(fields: [userId], references: [id])
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId    Int
   body      String
-  channel   Channel  @relation(fields: [channelId], references: [id])
+  channel   Channel  @relation(fields: [channelId], references: [id], onDelete: Cascade)
   channelId Int
   createdAt DateTime @default(now())
 }

--- a/back/src/chat/channel/channel.service.ts
+++ b/back/src/chat/channel/channel.service.ts
@@ -346,9 +346,6 @@ export class ChannelService {
 				});
 			}
 			if (!newOwner) {
-				await this.prisma.channelConnection.deleteMany({
-					where: { channelId: targetChannelId }
-				});
 				this.socialService.emit('chat:delete', targetChannelId);
 				await this.prisma.channel.delete({ where: { id: targetChannelId } });
 				return;
@@ -379,7 +376,7 @@ export class ChannelService {
 			await this.socialService.quitRoom(user.id, targetChannelId.toString());
 			if (foundChannel.channelConnection.length === 1) {
 				this.socialService.emit('chat:delete', targetChannelId);
-				await this.prisma.channel.delete({ where: { id: targetChannelId } });
+				await this.prisma.channel.delete({ where: { id: targetChannelId } })
 			}
 		}
 	}

--- a/back/src/chat/channel/channel.service.ts
+++ b/back/src/chat/channel/channel.service.ts
@@ -570,6 +570,7 @@ export class ChannelService {
 				});
 			});
 		}
+		
 
 		const channel = await this.prisma.channel
 			.update({
@@ -582,7 +583,7 @@ export class ChannelService {
 			})
 			.catch(() => {
 				throw new BadRequestException('Cannot update channel', {
-					description: 'Something went horribly wrong'
+					description: 'Name already taken'
 				});
 			});
 		this.socialService.emit('chat:update', channel);

--- a/back/src/chat/channel/channel.service.ts
+++ b/back/src/chat/channel/channel.service.ts
@@ -376,7 +376,7 @@ export class ChannelService {
 			await this.socialService.quitRoom(user.id, targetChannelId.toString());
 			if (foundChannel.channelConnection.length === 1) {
 				this.socialService.emit('chat:delete', targetChannelId);
-				await this.prisma.channel.delete({ where: { id: targetChannelId } })
+				await this.prisma.channel.delete({ where: { id: targetChannelId } });
 			}
 		}
 	}
@@ -567,7 +567,6 @@ export class ChannelService {
 				});
 			});
 		}
-		
 
 		const channel = await this.prisma.channel
 			.update({

--- a/back/src/chat/privmsg/privmsg.controller.ts
+++ b/back/src/chat/privmsg/privmsg.controller.ts
@@ -13,7 +13,6 @@ import {
 import type { Request } from '@type/request';
 import { AuthenticatedGuard } from '@guard/authenticated.guard';
 import { PrivmsgService } from './privmsg.service';
-import { Channel } from '@prisma/client';
 import { IsPrivmsgGuard } from '@guard/isPrivmsg.guard';
 import { IsUserSocketGuard } from '@guard/isUserSocket.guard';
 import { ChannelPasswordDto } from '@type/channel.dto';
@@ -22,9 +21,13 @@ import { ChannelPasswordDto } from '@type/channel.dto';
 export class PrivmsgController {
 	constructor(private readonly privmsgService: PrivmsgService) {}
 
+	/* This returns an object {
+	 * name: NameThatShouldBeDisplayedForChannel
+	 * channel: Channel
+	 */
 	@Get()
 	@UseGuards(...AuthenticatedGuard)
-	async getAll(@Req() req: Request): Promise<Channel[]> {
+	async getAll(@Req() req: Request) {
 		return await this.privmsgService.getAll(req.user.id);
 	}
 


### PR DESCRIPTION
Fixes name duplicates in channels.
Fixes channel deletions with exiting relations (messages or channelConnections)

Added events for privmsg.
Now joining rooms for privmsg.

Improved returns for get route on privmsg to return a name to be displayed.

Please note this changes the prisma schema so you will need to rebuild and clean volumes.