### PR TITLE
MERGE FIX USER NOT RETURNED WHEN PROMOTED AFTER QUIT:

### DIFF
--- a/back/src/chat/channel/channel.service.ts
+++ b/back/src/chat/channel/channel.service.ts
@@ -332,7 +332,8 @@ export class ChannelService {
 			}
 			const promotedOwner = await this.prisma.channelConnection.update({
 				where: { connectionId: { userId: newOwner.userId, channelId: newOwner.channelId } },
-				data: { role: ChannelRole.OWNER }
+				data: { role: ChannelRole.OWNER },
+				include: { channel: true, user: true }
 			});
 			this.socialService.emit('chat:promote', promotedOwner, targetChannelId.toString());
 			//disconnect the owner (shorter because we know he is not invited/banned)

--- a/front/components/chat/box.vue
+++ b/front/components/chat/box.vue
@@ -72,7 +72,7 @@ export default defineNuxtComponent({
     this.socket?.on('chat:promote', (data: any) => {
       if (data.channelId === this.$channel.id && data.userId === this.$auth.user.id)
         this.$channel.userRole = data.role;
-      if (data.userId == this.$auth.user.id)
+      if (data.userId === this.$auth.user.id)
         $event('alert:success', {message: `You are promoted to Admin on ${data.channel.name}`});
       else
         $event('alert:success', {message: `${data.user.username} is promoted on ${data.channel.name}`});
@@ -91,7 +91,7 @@ export default defineNuxtComponent({
     });
 
     this.socket?.on('chat:quit', (data: number) => {  
-      if (data == this.$auth.user.id)
+      if (data === this.$auth.user.id)
         $event('alert:success', {message: `You left`});
     });
 


### PR DESCRIPTION
The user was not returned with the chat:promote event, thus triggering an error because the data was incomplete when trying to produce an alert

missing = prevented correct display of the alert on quit and promote